### PR TITLE
add new option "sleep_after"

### DIFF
--- a/lib/parallel.rb
+++ b/lib/parallel.rb
@@ -402,6 +402,7 @@ module Parallel
               end
             end
           ensure
+            sleep if options[:sleep_after]
             worker.close_pipes
             worker.wait # if it goes zombie, rather wait here to be able to debug
           end
@@ -431,6 +432,7 @@ module Parallel
           parent_read.close
 
           process_incoming_jobs(child_read, child_write, job_factory, options, &block)
+        rescue Interrupt
         ensure
           child_read.close
           child_write.close


### PR DESCRIPTION
add new option "sleep_after"

With this option set, all workers after finishing their jobs fell into sleep in order to keep its data (e.g. network connections).
To kill program, just type Control-C. 
