### PR TITLE
fix --sleep-after option to finish Parallel but worker remains correctly

### DIFF
--- a/lib/parallel.rb
+++ b/lib/parallel.rb
@@ -402,9 +402,10 @@ module Parallel
               end
             end
           ensure
-            sleep if options[:sleep_after]
-            worker.close_pipes
-            worker.wait # if it goes zombie, rather wait here to be able to debug
+            unless options[:sleep_after]
+              worker.close_pipes
+              worker.wait # if it goes zombie, rather wait here to be able to debug
+            end
           end
         end
       end


### PR DESCRIPTION
Do not sleep worker directly, but keep pipes open with workers